### PR TITLE
Fix Camera node reference in example level

### DIFF
--- a/scripts/Level.gd
+++ b/scripts/Level.gd
@@ -7,7 +7,7 @@ func _ready():
 
 	# - The Camera3D lets the player know which direction he should be facing when
 	#   moving around 
-	$Cole.camera = $Camera3D
+	$Cole.camera = $Camera
 	
 	# We need to initialize our point and click system letting it know:
 	# - Who's the player


### PR DESCRIPTION
There is no node called "Camera3D" in the scene tree. It should be "Camera".